### PR TITLE
Make paths relative

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <title>Yew</title>
-    <script src="/pkg/bundle.js" defer></script>
+    <script src="./pkg/bundle.js" defer></script>
 </head>
 
 <body>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 import init, { run_app } from './pkg/yew_wasm_pack_minimal.js';
 async function main() {
-   await init('/pkg/yew_wasm_pack_minimal_bg.wasm');
+   await init('./pkg/yew_wasm_pack_minimal_bg.wasm');
    run_app();
 }
 main()


### PR DESCRIPTION
This PR changes two paths from absolute to relative. This fixed 404s when serving the app from a route other than `/`. With these changes, the app can be deployed to github pages for example with wasn't working before (e.g. see this [repo](https://github.com/fkohlgrueber/github-deploy); [rendered](https://fkohlgrueber.github.io/github-deploy/)).

As far as I can see, this doesn't break any existing cases.