### PR TITLE
bump wasm-bindgen, yew, rust && migrate from a struct based component to a functional component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 authors = [
     "Kelly Thomas Kline <kellytk@sw-e.org>",
-    "Samuel Rounce <me@samuelrounce.co.uk>"
+    "Samuel Rounce <me@samuelrounce.co.uk>",
+    "Mahmoud Harmouch <oss@wiseai.dev>"
 ]
 categories = ["gui", "wasm", "web-programming"]
 description = "yew-wasm-pack-minimal demonstrates the minimum code and tooling necessary for a frontend web app with simple deployable artifacts consisting of one HTML file, one JavaScript file, and one WebAssembly file, using Yew, wasm-bindgen, and wasm-pack."
-edition = "2018"
+edition = "2021"
 keywords = ["yew", "wasm", "wasm-bindgen", "web"]
 license = "MIT/Apache-2.0"
 name = "yew-wasm-pack-minimal"
 readme = "README.md"
 repository = "https://github.com/yewstack/yew-wasm-pack-minimal"
-version = "0.1.0"
+version = "0.1.1"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "^0.2"
-yew = "0.17"
+wasm-bindgen = "0.2.87"
+yew = { version = "0.21.0", features = ["csr"] }

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019 {{authors}}
+Copyright (c) 2023 Yew Stack Core Team
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2018"
+edition = "2021"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,28 +1,8 @@
 use yew::prelude::*;
 
-pub struct App {}
-
-pub enum Msg {}
-
-impl Component for App {
-    type Message = Msg;
-    type Properties = ();
-
-    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
-        App {}
-    }
-
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        true
-    }
-
-    fn change(&mut self, _: Self::Properties) -> ShouldRender {
-        false
-    }
-
-    fn view(&self) -> Html {
-        html! {
-            <p>{ "Hello world!" }</p>
-        }
+#[function_component(App)]
+pub fn app() -> Html {
+    html! {
+        <p>{ "Hello world!" }</p>
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@ mod app;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn run_app() -> Result<(), JsValue> {
-    yew::start_app::<app::App>();
-
-    Ok(())
+pub fn run_app() {
+    yew::Renderer::<app::App>::new().render();
 }


### PR DESCRIPTION
Output:

```sh
$ python3 -m http.server 8080
Serving HTTP on 0.0.0.0 port 8080 (http://0.0.0.0:8080/) ...
127.0.0.1 - - [19/Oct/2023 11:12:48] "GET / HTTP/1.1" 200 -
```

![Screenshot from 2023-10-19 11-13-05](https://github.com/yewstack/yew-wasm-pack-minimal/assets/62179149/fe5b0dfe-ba05-4880-9320-9b281cba416d)

P.S. I'm aware that `Trunk` is the norm these days, but I thought it would be great to upgrade this repository for those who are still working with `wasm-pack` and good ol' WebAssembly.
